### PR TITLE
fix: update PostCSS config for Tailwind CSS v4 compatibility

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    'tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    'tailwindcss/postcss': {},
+    "tailwindcss/postcss": {},
     autoprefixer: {},
   },
-}
+};


### PR DESCRIPTION
## Summary
- Tailwind CSS v4 moved the PostCSS plugin entrypoint from `tailwindcss` to `tailwindcss/postcss`
- The old entrypoint caused the Netlify build to fail with: _"It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin"_
- Updated `postcss.config.js` to use `'tailwindcss/postcss': {}` instead of `tailwindcss: {}`

## Test plan
- [ ] Netlify deploy should now succeed with the updated PostCSS config
- [ ] Verify CSS/Tailwind styles render correctly in the deployed preview

Fixes GIV-504

🤖 Generated with [Claude Code](https://claude.com/claude-code)