### PR TITLE
fix: use @tailwindcss/postcss package for Tailwind v4 PostCSS integra…

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "zustand": "5.0.12"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.2",
     "@eslint/js": "^10.0.1",
     "@types/bcryptjs": "^3.0.0",
     "@types/cors": "^2.8.19",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    "tailwindcss/postcss": {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
…tion

In Tailwind CSS v4 the PostCSS plugin was extracted into the separate @tailwindcss/postcss package. The previous attempt used 'tailwindcss/postcss' (a non-existent subpath export) which caused Netlify builds to abort. The correct key is '@tailwindcss/postcss', and the package is now added to devDependencies.