### PR TITLE
fix: use Tailwind v4 CSS import syntax for theme resolution

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -1,6 +1,5 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@config "../tailwind.config.js";
 
 @layer base {
   :root {


### PR DESCRIPTION
Replace v3 @tailwind directives with @import "tailwindcss" and @config to load the existing config in v4 compat mode. This fixes "Cannot apply unknown utility class border-border" build error.