### PR TITLE
fix(security): fail-closed JWT/session secrets (GIV-550)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,15 @@
 # Format: postgres://username:password@host:port/database
 DATABASE_URL=postgres://your_username:your_password@localhost:5432/commonry
 
-# ==================== JWT AUTHENTICATION ====================
-# Secret key for signing JWT tokens (use a strong random string)
-# Generate with: openssl rand -base64 32
-JWT_SECRET=your-secret-key-change-in-production
+# ==================== AUTHENTICATION SECRETS ====================
+# REQUIRED — the server will refuse to start without these.
+# Generate each with: openssl rand -base64 32
+
+# Secret key for signing JWT tokens
+JWT_SECRET=CHANGE_ME_generate_with_openssl_rand_base64_32
+
+# Secret key for express-session cookies (Discourse SSO flow)
+SESSION_SECRET=CHANGE_ME_generate_with_openssl_rand_base64_32
 
 # ==================== EMAIL SERVICE ====================
 # Email service for verification emails (using Nodemailer)

--- a/server.js
+++ b/server.js
@@ -44,7 +44,7 @@ if (missingSecrets.length > 0) {
       "The server cannot start without these secrets. " +
       "See .env.example for required configuration.",
   );
-  process.exit(1);
+  process.exit(1); // skipcq: JS-0263 -- intentional fail-closed startup guard: halt boot when required secrets are absent
 }
 
 const __filename = fileURLToPath(import.meta.url);

--- a/server.js
+++ b/server.js
@@ -33,6 +33,20 @@ import { createLearningAnalyticsRoutes } from "./learning-analytics-routes.js";
 
 dotenv.config();
 
+// Fail-closed: require critical secrets at startup
+const requiredSecrets = ["JWT_SECRET", "SESSION_SECRET"];
+const missingSecrets = requiredSecrets.filter(
+  (key) => !process.env[key] || process.env[key].trim() === "",
+);
+if (missingSecrets.length > 0) {
+  console.error(
+    `FATAL: Missing required environment variable(s): ${missingSecrets.join(", ")}. ` +
+      "The server cannot start without these secrets. " +
+      "See .env.example for required configuration.",
+  );
+  process.exit(1);
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -134,7 +148,7 @@ app.use(generalLimiter);
 // Session middleware for Discourse SSO
 app.use(
   session({
-    secret: process.env.JWT_SECRET || "your-secret-key-change-in-production",
+    secret: process.env.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
     cookie: {
@@ -167,8 +181,7 @@ app.get("/", (req, res) => {
 });
 
 // JWT configuration
-const JWT_SECRET =
-  process.env.JWT_SECRET || "your-secret-key-change-in-production";
+const JWT_SECRET = process.env.JWT_SECRET;
 const JWT_EXPIRES_IN = "7d";
 
 // Discourse SSO configuration


### PR DESCRIPTION
## Summary

**CEO-authorized emergency security hotfix (Phase 0, S1 only).**

- Removes the hardcoded literal fallback `"your-secret-key-change-in-production"` from both the session secret (`server.js:137`) and JWT signing key (`server.js:171`). This default was publicly known and could be used to forge valid auth tokens.
- Server now **fails closed** at startup with a clear error if `JWT_SECRET` or `SESSION_SECRET` environment variables are missing or empty.
- Session middleware now uses its own dedicated `SESSION_SECRET` (was previously sharing `JWT_SECRET`).
- `.env.example` updated with both required vars, placeholder values only, and generation instructions.
- Grep-verified: the literal fallback string no longer appears anywhere in the repository.

**DO NOT DEPLOY** until CTO confirms prod has real secrets set.

Fixes GIV-550 (child of GIV-549).

## Test plan

- [ ] With both `JWT_SECRET` and `SESSION_SECRET` unset: server exits with `FATAL: Missing required environment variable(s): JWT_SECRET, SESSION_SECRET`
- [ ] With only `JWT_SECRET` set: server exits naming `SESSION_SECRET`
- [ ] With only `SESSION_SECRET` set: server exits naming `JWT_SECRET`
- [ ] With both set to valid values: server boots normally
- [ ] `grep -r "your-secret-key-change-in-production" .` returns zero matches
- [ ] Auth flow (JWT sign/verify) works end-to-end with real secrets
- [ ] Discourse SSO flow works with separate `SESSION_SECRET`

🤖 Generated with [Claude Code](https://claude.com/claude-code)