### PR TITLE
fix: drop unused _decks binding in anki import (DeepSource JS-0128)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2000,8 +2000,8 @@ app.post(
 
       await client.query("BEGIN");
 
-      // Get deck info from Anki
-      const _decks = ankiDb.prepare("SELECT * FROM col").get();
+      // Validate that the uploaded file is a proper Anki database (throws if col table is missing)
+      ankiDb.prepare("SELECT * FROM col").get();
       const deckName = req.body.deckName || "Imported Deck";
 
       // Create deck in our database


### PR DESCRIPTION
## Summary

Resolves DeepSource `JS-0128` (unused variable) flagged in `server.js` anki-import path — tech debt from GIV-554 that was intentionally excluded from the GIV-550 security hotfix (PR #342) to keep that PR scoped.

**Analysis of the `SELECT * FROM col` query:**
- The `col` table is Anki's core metadata table; every valid `.anki2`/`.anki21b` file has one.
- If the table is absent, better-sqlite3 throws `"no such table: col"`, which the surrounding `catch` block surfaces as a 500 to the client — implicit but real validation.
- The returned row was never read; only the side-effect (throw-on-bad-file) matters.

**Change:** remove `const _decks =` binding, keep the query, and replace the misleading `// Get deck info from Anki` comment with one that makes the validation intent explicit.

## Test plan

- [ ] Upload a valid `.apkg` file → import succeeds, cards inserted as before.
- [ ] Upload a SQLite file **without** a `col` table → server returns 500 with a clear error.
- [ ] DeepSource JS-0128 no longer reported on `server.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)