### PR TITLE
fix(security): bump nodemailer to 9.0.3 — close GIV-600 (GHSA-p6gq-j5cr-w38f)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "lucide-react": "^1.8.0",
         "lusca": "^1.7.0",
         "multer": "^2.1.1",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "9.0.3",
         "pg": "^8.20.0",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -5992,9 +5992,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
-      "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lucide-react": "^1.8.0",
     "lusca": "^1.7.0",
     "multer": "^2.1.1",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "9.0.3",
     "pg": "^8.20.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",
@@ -58,8 +58,8 @@
     "zustand": "5.0.12"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.2.2",
     "@eslint/js": "^10.0.1",
+    "@tailwindcss/postcss": "^4.2.2",
     "@types/bcryptjs": "^3.0.0",
     "@types/cors": "^2.8.19",
     "@types/dompurify": "^3.2.0",


### PR DESCRIPTION
## Summary

Clears the final high-severity vulnerability on the `npm audit` report (GIV-600).

- Pins `nodemailer` to **9.0.3** (was `^8.0.5`)
- `npm audit` now reports **0 vulnerabilities** (previously 1 high)
- Build confirmed passing: `vite build` exits clean (chunk-size warnings only)

## Security context

`GHSA-p6gq-j5cr-w38f`: nodemailer ≤9.0.0 allowed the message-level `raw` option to bypass `disableFileAccess`/`disableUrlAccess`, enabling arbitrary file read and full-response SSRF in delivered messages.

**Breaking change is safe for this codebase:** `email-service.js` uses only `createTransport`, `sendMail`, `createTestAccount`, and `getTestMessageUrl` — all unchanged in v9. The sole v9 breaking change (stricter TLS cert validation) does not affect our `STARTTLS`+`requireTLS` configuration.

## Note on prior vulns

The other 7 vulnerabilities (DOMPurify, multer, vite, brace-expansion, ip-address, tar, @babel/core) were already resolved in `origin/main` before this PR. This PR adds only the nodemailer pin.

## Test plan

- [x] `npm audit` → `found 0 vulnerabilities`
- [x] `npm run build` → exits clean
- [x] `SafeHtml` component uses explicit `ALLOWED_TAGS`/`ALLOWED_ATTR` allowlist; none of the fixed DOMPurify advisories target this usage pattern (no `ADD_TAGS`, `FORBID_TAGS`, `IN_PLACE`, or `RETURN_DOM` used)

Closes GIV-600

🤖 Generated with [Claude Code](https://claude.com/claude-code)