### PR TITLE
ci: stand up CI gate — lint, typecheck, npm audit, build (GIV-603)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     name: lint / typecheck / audit / build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: lint / typecheck / audit / build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Audit (high+)
+        run: npm audit --audit-level=high
+
+      - name: Build
+        run: npm run build

--- a/add-sample-stats.js
+++ b/add-sample-stats.js
@@ -84,7 +84,9 @@ async function addSampleStats() {
     process.exitCode = 0;
   } catch (error) {
     console.error("❌ Error adding sample stats:", error);
-    throw new Error(`Error adding sample stats: ${error.message}`, { cause: error });
+    throw new Error(`Error adding sample stats: ${error.message}`, {
+      cause: error,
+    });
   }
 }
 

--- a/add-sample-stats.js
+++ b/add-sample-stats.js
@@ -84,7 +84,7 @@ async function addSampleStats() {
     process.exitCode = 0;
   } catch (error) {
     console.error("❌ Error adding sample stats:", error);
-    throw new Error(`Error adding sample stats: ${error.message}`);
+    throw new Error(`Error adding sample stats: ${error.message}`, { cause: error });
   }
 }
 

--- a/card-analysis-service.js
+++ b/card-analysis-service.js
@@ -207,7 +207,7 @@ export class CardAnalysisService {
     }
 
     if (minVersion) {
-      whereClause += ` AND ca.analysis_version < $${paramIndex++}`;
+      whereClause += ` AND ca.analysis_version < $${paramIndex}`;
       params.push(minVersion);
     }
 

--- a/check-db.js
+++ b/check-db.js
@@ -23,7 +23,7 @@ async function checkDatabase() {
     return;
   } catch (error) {
     console.error("Error:", error);
-    throw new Error(error);
+    throw new Error("Database check failed", { cause: error });
   }
 }
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,9 +57,51 @@ export default typescript.config(
       "@typescript-eslint/no-non-null-assertion": "warn",
 
       // General Rules
+      // TS itself reports undefined identifiers; no-undef is redundant for
+      // .ts/.tsx and false-positives on DOM/node globals (typescript-eslint FAQ).
+      "no-undef": "off",
       "no-console": ["warn", { allow: ["warn", "error"] }],
       "prefer-const": "warn",
       "no-var": "error",
+    },
+  },
+  {
+    // Root-level Node.js server/scripts (CommonJS/ESM run under Node)
+    files: ["**/*.{js,cjs,mjs}"],
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        process: "readonly",
+        Buffer: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        require: "readonly",
+        module: "writable",
+        exports: "writable",
+        global: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        setImmediate: "readonly",
+        URL: "readonly",
+        URLSearchParams: "readonly",
+        AbortController: "readonly",
+        TextEncoder: "readonly",
+        TextDecoder: "readonly",
+        fetch: "readonly",
+        crypto: "readonly",
+        structuredClone: "readonly",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "lucide-react": "^1.8.0",
         "lusca": "^1.7.0",
         "multer": "^2.1.1",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "9.0.3",
         "pg": "^8.20.0",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -5992,9 +5992,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
-      "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "node server.js",
-    "lint": "eslint . --ext .ts,.tsx",
-    "lint:fix": "eslint . --ext .ts,.tsx --fix"
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   },
   "keywords": [],
   "author": "",
@@ -45,7 +45,7 @@
     "lucide-react": "^1.8.0",
     "lusca": "^1.7.0",
     "multer": "^2.1.1",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "9.0.3",
     "pg": "^8.20.0",
     "react": "19.2.5",
     "react-dom": "19.2.5",
@@ -58,8 +58,8 @@
     "zustand": "5.0.12"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.2.2",
     "@eslint/js": "^10.0.1",
+    "@tailwindcss/postcss": "^4.2.2",
     "@types/bcryptjs": "^3.0.0",
     "@types/cors": "^2.8.19",
     "@types/dompurify": "^3.2.0",

--- a/server.js
+++ b/server.js
@@ -201,7 +201,7 @@ const authenticateToken = (req, res, next) => {
     req.userId = decoded.userId;
     next();
     return null;
-  } catch (error) {
+  } catch {
     return res.status(403).json({ error: "Invalid or expired token" });
   }
 };
@@ -2087,7 +2087,7 @@ app.post(
             dirReal = dirReal + path.sep;
           }
           return fileReal.startsWith(dirReal);
-        } catch (e) {
+        } catch {
           // Could not resolve path; treat as not contained
           return false;
         }
@@ -2115,7 +2115,7 @@ app.post(
             );
             // Get the canonical path for symlink protection
             uploadedFileRealPath = fs.realpathSync(absUploadedPath);
-          } catch (e) {
+          } catch {
             // If realpathSync fails, keep as null
             uploadedFileRealPath = null;
           }

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { TerminalButton } from "../ui/TerminalButton";
 import { TypingCursor } from "../ui/TypingCursor";
-import { Github } from "lucide-react";
+import { GitFork } from "lucide-react";
 
 type View = "home" | "study" | "browse" | "stats" | "square" | "profile";
 
@@ -56,7 +56,7 @@ export function Navigation({ onNavigate, onSignIn }: NavigationProps) {
               rel="noopener noreferrer"
               className="text-text-muted hover:text-cyan font-mono text-sm transition-colors flex items-center gap-2"
             >
-              <Github size={16} />
+              <GitFork size={16} />
               [GitHub]
             </a>
             <a

--- a/src/lib/anki-export.ts
+++ b/src/lib/anki-export.ts
@@ -92,7 +92,10 @@ export async function exportAnkiDeck(
       const card = cards[cardIndex];
 
       // Try to get original Anki card ID from mapping service
-      let ankiCardExternalId = await ImportMappingService.getExternalId(card.id, "anki");
+      let ankiCardExternalId = await ImportMappingService.getExternalId(
+        card.id,
+        "anki",
+      );
 
       // Fall back to externalId field if mapping not found
       if (!ankiCardExternalId && card.externalId) {
@@ -115,7 +118,9 @@ export async function exportAnkiDeck(
           noteId = ankiCardExternalId;
           // Try to parse as integer, or generate new one
           const parsedId = parseInt(ankiCardExternalId);
-          ankiCardIdInt = isNaN(parsedId) ? baseTimestamp + cardIndex : parsedId;
+          ankiCardIdInt = isNaN(parsedId)
+            ? baseTimestamp + cardIndex
+            : parsedId;
         }
       } else {
         // Generate new IDs for cards that were never imported
@@ -280,7 +285,11 @@ function initializeAnkiSchema(database: Database, _deck: Deck): void {
 /**
  * Insert deck into Anki database
  */
-function insertDeck(database: Database, deckId: string, deckName: string): void {
+function insertDeck(
+  database: Database,
+  deckId: string,
+  deckName: string,
+): void {
   const now = Math.floor(Date.now() / 1000);
 
   // Get existing decks JSON
@@ -306,7 +315,9 @@ function insertDeck(database: Database, deckId: string, deckName: string): void 
   };
 
   // Update col table
-  database.run("UPDATE col SET decks = ? WHERE id = 1", [JSON.stringify(decks)]);
+  database.run("UPDATE col SET decks = ? WHERE id = 1", [
+    JSON.stringify(decks),
+  ]);
 }
 
 /**
@@ -367,7 +378,9 @@ function insertBasicModel(database: Database, modelId: string): void {
   };
 
   // Update col table
-  database.run("UPDATE col SET models = ? WHERE id = 1", [JSON.stringify(models)]);
+  database.run("UPDATE col SET models = ? WHERE id = 1", [
+    JSON.stringify(models),
+  ]);
 }
 
 /**
@@ -445,7 +458,8 @@ function insertCard(
  * Generate a GUID for Anki note
  */
 function generateGUID(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   let result = "";
   for (let i = 0; i < 10; i++) {
     result += chars.charAt(Math.floor(Math.random() * chars.length));

--- a/src/lib/anki-export.ts
+++ b/src/lib/anki-export.ts
@@ -159,6 +159,7 @@ export async function exportAnkiDeck(
     console.error("Error exporting Anki deck:", error);
     throw new Error(
       `Failed to export Anki deck: ${error instanceof Error ? error.message : "Unknown error"}`,
+      { cause: error },
     );
   }
 }

--- a/src/lib/anki-import.ts
+++ b/src/lib/anki-import.ts
@@ -224,6 +224,7 @@ async function loadCollectionDatabase(
     } catch (e) {
       throw new Error(
         "Failed to decompress collection.anki21b file. The file may be corrupted.",
+        { cause: e },
       );
     }
   } else {
@@ -731,6 +732,7 @@ export async function importAnkiDeck(
 
     throw new Error(
       `Failed to import Anki deck: ${error instanceof Error ? error.message : "Unknown error"}`,
+      { cause: error },
     );
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
@@ -16,7 +16,6 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running on every PR/push to main: `npm run lint`, `tsc --noEmit`, `npm audit --audit-level=high`, `vite build` (single required check: `lint / typecheck / audit / build`).
- Makes all four gates green:
  - **audit:** `npm audit fix` + nodemailer 8→9.0.3 → **0 vulnerabilities** (cleared multer/vite/nodemailer highs). Overlaps #345 — same nodemailer version, whichever merges second rebases trivially.
  - **typecheck:** removed deprecated `baseUrl` (TS5101 under TS 6), lib/target → ES2022; replaced removed `Github` lucide icon with `GitFork`.
  - **lint:** flat-config fixes (node globals for root `.js` server files; `no-undef` off for TS per typescript-eslint guidance; `_`-prefix ignores). Fixed the 16 real errors (error `cause` propagation, unused catch bindings, useless increment). 0 errors, 87 warnings remain (warnings don't fail the gate).
- Follow-up (separate): make the `ci` check required on `main` branch protection once this run is green.

Parent issue: GIV-503 · Task: GIV-603

## Test plan
- [x] All four gates run green locally
- [ ] CI workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)