### PR TITLE
fix(security): restore CSRF protection via Origin/Referer validation (GIV-617)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "jsonwebtoken": "^9.0.3",
         "jszip": "^3.10.1",
         "lucide-react": "^1.8.0",
-        "lusca": "^1.7.0",
         "multer": "^2.1.1",
         "nodemailer": "9.0.3",
         "pg": "^8.20.0",
@@ -5551,17 +5550,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/lusca": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
-      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
-      "dependencies": {
-        "tsscmp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7552,15 +7540,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.x"
-      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "jsonwebtoken": "^9.0.3",
     "jszip": "^3.10.1",
     "lucide-react": "^1.8.0",
-    "lusca": "^1.7.0",
     "multer": "^2.1.1",
     "nodemailer": "9.0.3",
     "pg": "^8.20.0",

--- a/server.js
+++ b/server.js
@@ -160,9 +160,40 @@ app.use(
   }),
 );
 
-// CSRF protection removed - not needed for JWT-based API authentication
-// JWT tokens are sent via Authorization header, not cookies, so they're not vulnerable to CSRF
-// Discourse SSO is protected by signed payloads (sig parameter) instead
+// CSRF protection via Origin/Referer validation (GIV-617, CodeQL alert #29)
+// JWT auth uses the Authorization header, which browsers never attach cross-site,
+// but the Discourse SSO session cookie IS ambient credential state. Token-based
+// CSRF (lusca) breaks the cross-origin SPA, so instead we reject state-mutating
+// requests whose browser-supplied Origin/Referer is not an allowed origin.
+const CSRF_SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+app.use((req, res, next) => {
+  if (CSRF_SAFE_METHODS.has(req.method)) {
+    return next();
+  }
+
+  let source = req.headers.origin;
+  if (!source && req.headers.referer) {
+    try {
+      source = new URL(req.headers.referer).origin;
+    } catch {
+      return res.status(403).json({ error: "Invalid Referer header" });
+    }
+  }
+
+  // No Origin and no Referer means a non-browser client (curl, mobile app,
+  // server-to-server). Those carry no ambient cookie credentials, so CSRF
+  // does not apply - allow them through to normal authentication.
+  if (!source) {
+    return next();
+  }
+
+  if (allowedOrigins.includes(source)) {
+    return next();
+  }
+
+  console.warn(`CSRF blocked cross-site ${req.method} from origin: ${source}`);
+  return res.status(403).json({ error: "Cross-site request rejected" });
+});
 
 // Root route - API info
 app.get("/", (req, res) => {


### PR DESCRIPTION
## Summary
- **Regression:** CodeQL alert #29 (missing CSRF middleware) was fixed with `lusca.csrf()` in `85b0d82`, then silently removed 5 days later in `6c4c346` ("Allow multiple CORS origins"), leaving all state-mutating routes without CSRF protection.
- **Why not restore lusca:** token-based CSRF breaks the cross-origin SPA (it never fetches/sends a CSRF token) — that's almost certainly why it was removed with the CORS change. Restoring it would break every SPA POST.
- **Fix (modern approach per GIV-617):** middleware rejects `POST/PUT/DELETE/PATCH` requests whose browser-supplied `Origin` (or `Referer` fallback) is not in `allowedOrigins`, returning 403. Requests with neither header are non-browser clients (curl/mobile/server-to-server) with no ambient cookie credentials — CSRF doesn't apply, they pass through to normal JWT auth. This closes the residual risk around the Discourse SSO session cookie and the referer-only/no-Origin edge cases that the CORS layer doesn't cover cleanly.
- Removes `lusca` from deps (dead since `6c4c346`).

## Test plan
- [x] `node --check server.js` + eslint clean
- [x] Live server: evil `Referer`-only POST → 403 `{"error":"Cross-site request rejected"}`
- [x] Malformed `Referer` POST → 403
- [x] Allowed-origin / allowed-referer / no-origin POSTs pass through to route validation (400 from login handler as expected)
- [x] GET/HEAD/OPTIONS unaffected
- [ ] CI gate (lint / typecheck / audit / build)

Closes GIV-617. Parent: GIV-503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)