### PR TITLE
chore: fix package.json metadata (GIV-604)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint . --fix"
   },
   "keywords": [],
-  "author": "",
+  "author": "Give Protocol Foundation",
   "license": "ISC",
   "overrides": {
     "tailwindcss": "4.2.2"
@@ -84,11 +84,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/GiveProtocol/AestheticAnki.git"
+    "url": "git+https://github.com/GiveProtocolFoundation/Commonry.git"
   },
   "bugs": {
-    "url": "https://github.com/GiveProtocol/AestheticAnki/issues"
+    "url": "https://github.com/GiveProtocolFoundation/Commonry/issues"
   },
-  "homepage": "https://github.com/GiveProtocol/AestheticAnki#readme",
+  "homepage": "https://commonry.app",
   "description": "Your commons for lifelong learning"
 }


### PR DESCRIPTION
## Summary
- Point `repository`/`bugs` at `GiveProtocolFoundation/Commonry` (was stale `GiveProtocol/AestheticAnki`)
- Set `homepage` to https://commonry.app
- Set `author` to Give Protocol Foundation

`license` is intentionally left as `ISC` for now: switching to AGPL-3.0 (README intent) requires Foundation legal/board sign-off, requested on GIV-604. Once approved, license text will be fetched from the canonical GNU URL in a follow-up.

## Test plan
- [x] `node -e "require('./package.json')"` — valid JSON
- [ ] CI gate (lint / typecheck / audit / build) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)